### PR TITLE
Fix package description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
-
+import os
+from contextlib import suppress
 from setuptools import setup, find_packages
+
+project_root = os.path.dirname(__file__)
 
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -17,6 +20,12 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
+long_description = ''
+
+with suppress(OSError):
+    with open(os.path.join(project_root, 'README.md'), 'rt') as readme_fh:
+        long_description = readme_fh.read()
+
 setup(
     name='searchguard',
     version='0.2',
@@ -25,6 +34,7 @@ setup(
     author='Jeroen van Heugten',
     author_email='jeroen@byte.nl',
     classifiers=classifiers,
+    long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=[
         'requests==2.20'

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     name='searchguard',
     version='0.2',
     packages=find_packages(exclude=['tests']),
+    license='MIT',
     url='https://github.com/ByteInternet/searchguard-python',
     author='Jeroen van Heugten',
     author_email='jeroen@byte.nl',


### PR DESCRIPTION
Adds extra [metadata](https://python-packaging.readthedocs.io/en/latest/metadata.html) to the package.

* Add `long_description` param to `setup.py`: so the project description is available on `pypi`
* Add `license` param to `setup.py`: so the metadata of the build artifacts (wheels, ...) include the license