### PR TITLE
Remove ignoring Python warnings

### DIFF
--- a/searchguard/internalusers.py
+++ b/searchguard/internalusers.py
@@ -8,8 +8,6 @@ import string
 from searchguard.exceptions import *
 from searchguard.settings import HEADER, SGAPI, TOKEN
 
-warnings.filterwarnings("ignore")
-
 
 def password_generator(size=25, chars=string.ascii_uppercase + string.ascii_lowercase + string.digits):
     """Returns a random 25 character password"""

--- a/searchguard/roles.py
+++ b/searchguard/roles.py
@@ -6,8 +6,6 @@ import json
 from searchguard.exceptions import *
 from searchguard.settings import HEADER, SGAPI, TOKEN
 
-warnings.filterwarnings("ignore")
-
 
 def check_role_exists(role):
     """Returns True of False depending on whether the requested role exists in Search Guard"""


### PR DESCRIPTION
It's better for the library not to change global settings like this, and let the calling application to decide how to handle warnings.