### PR TITLE
Improved creation exceptions

### DIFF
--- a/searchguard/exceptions.py
+++ b/searchguard/exceptions.py
@@ -18,6 +18,10 @@ class CreateRoleException(SearchGuardException):
     pass
 
 
+class RoleAlreadyExistsException(CreateRoleException):
+    pass
+
+
 class DeleteRoleException(SearchGuardException):
     pass
 

--- a/searchguard/exceptions.py
+++ b/searchguard/exceptions.py
@@ -6,6 +6,10 @@ class CreateUserException(SearchGuardException):
     pass
 
 
+class UserAlreadyExistsException(CreateUserException):
+    pass
+
+
 class DeleteUserException(SearchGuardException):
     pass
 

--- a/searchguard/internalusers.py
+++ b/searchguard/internalusers.py
@@ -30,10 +30,13 @@ def check_user_exists(username):
 
 
 def create_user(username):
-    """Creates a new Search Guard user and returns the generated password"""
+    """Creates a new Search Guard user and returns the generated password
+
+    :param str username: the username
+    :raises: UserAlreadyExistsException, CreateUserException
+    """
     if check_user_exists(username):
-        # Raise exception because the user already exists
-        raise CreateUserException('User {} already exists'.format(username))
+        raise UserAlreadyExistsException('User {} already exists'.format(username))
 
     # The username does not exist, let's create it
     password = password_generator()

--- a/searchguard/roles.py
+++ b/searchguard/roles.py
@@ -25,8 +25,10 @@ def check_role_exists(role):
 def create_role(role, permissions=None):
     """Creates a Search Guard role. Returns when successfully created
     When no permissions are specified, we use some default cluster permissions.
+
     :param str role: Name of the role to create in Search Guard
     :param dict permissions: Search Guard role permissions (default is read access to cluster)
+    :raises: RoleAlreadyExistsException, CreateRoleException
     """
     if not check_role_exists(role):
         # The role does not exist, let's create it
@@ -44,8 +46,7 @@ def create_role(role, permissions=None):
             # Raise exception because we received an error when creating the role
             raise CreateRoleException('Error creating role {} - msg: {}'.format(role, create_sg_role.text))
     else:
-        # Raise exception because the role already exists
-        raise CreateRoleException('Role {} already exists'.format(role))
+        raise RoleAlreadyExistsException('Role {} already exists'.format(role))
 
 
 def modify_role(role, permissions):

--- a/tests/tests_internalusers/test_create_user.py
+++ b/tests/tests_internalusers/test_create_user.py
@@ -5,7 +5,7 @@ import mock as mock
 from tests.helper import BaseTestCase
 from mock import patch, Mock
 from searchguard.internalusers import create_user, password_generator
-from searchguard.exceptions import CreateUserException
+from searchguard.exceptions import CreateUserException, UserAlreadyExistsException
 
 
 class TestCreateUser(BaseTestCase):
@@ -31,13 +31,19 @@ class TestCreateUser(BaseTestCase):
         ret = create_user(self.user)
         self.assertEqual(len(ret), 25)
 
-    def test_create_user_returns_exception_when_user_already_exists(self):
+    def test_create_user_raises_create_exception_when_user_already_exists(self):
         self.mocked_check_user_exists.return_value = True
 
         with self.assertRaises(CreateUserException):
             create_user(self.user)
 
-    def test_create_user_returns_exception_when_requests_return_code_not_201(self):
+    def test_create_user_raises_specific_exception_when_user_already_exists(self):
+        self.mocked_check_user_exists.return_value = True
+
+        with self.assertRaises(UserAlreadyExistsException):
+            create_user(self.user)
+
+    def test_create_user_raises_exception_when_requests_return_code_not_201(self):
         self.mocked_requests_put.return_value = Mock(status_code=999)
 
         with self.assertRaises(CreateUserException):

--- a/tests/tests_roles/test_create_role.py
+++ b/tests/tests_roles/test_create_role.py
@@ -5,7 +5,7 @@ import mock as mock
 from tests.helper import BaseTestCase
 from mock import Mock
 from searchguard.roles import create_role
-from searchguard.exceptions import CreateRoleException
+from searchguard.exceptions import CreateRoleException, RoleAlreadyExistsException
 
 
 class TestCreateRole(BaseTestCase):
@@ -22,16 +22,22 @@ class TestCreateRole(BaseTestCase):
         self.mocked_check_role_exists = self.set_up_patch('searchguard.roles.check_role_exists')
         self.mocked_check_role_exists.return_value = False
 
-    def test_create_role_returns_when_successfully_created_role(self):
+    def test_create_role_returns_none_when_successfully_created_role(self):
         self.assertIsNone(create_role(self.role, self.permissions))
 
-    def test_create_role_returns_exception_when_role_already_exists(self):
+    def test_create_role_raises_create_exception_when_role_already_exists(self):
         self.mocked_check_role_exists.return_value = True
 
         with self.assertRaises(CreateRoleException):
             create_role(self.role, self.permissions)
 
-    def test_create_role_returns_exception_when_requests_return_code_not_201(self):
+    def test_create_role_raises_specific_exception_when_role_already_exists(self):
+        self.mocked_check_role_exists.return_value = True
+
+        with self.assertRaises(RoleAlreadyExistsException):
+            create_role(self.role, self.permissions)
+
+    def test_create_role_raises_exception_when_requests_return_code_not_201(self):
         self.mocked_requests_put.return_value = Mock(status_code=999)
 
         with self.assertRaises(CreateRoleException):


### PR DESCRIPTION
When creating users/roles if the user/role exists, raise a specific type of exception, so the caller knows about such conditions (opposed to a real error), and decide how to cope with the situation.

This is specially helpful for idempotant actions where the caller just needs to ensure if a user/role exists and existing entities are not considered an error. 