### PR TITLE
Relaxed default settings when no env is set

### DIFF
--- a/searchguard/settings.py
+++ b/searchguard/settings.py
@@ -1,5 +1,5 @@
 import os
 
 HEADER = {'content-type': 'application/json'}
-SGAPI = os.environ['SEARCHGUARD_API_URL']
-TOKEN = (os.environ['SEARCHGUARD_API_USER'], os.environ['SEARCHGUARD_API_PASS'])
+SGAPI = os.environ.get('SEARCHGUARD_API_URL', '')
+TOKEN = (os.environ.get('SEARCHGUARD_API_USER', ''), os.environ.get('SEARCHGUARD_API_PASS', ''))

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,3 @@ deps = -rrequirements/development.txt
 commands=pytest --cov=searchguard tests/
          pycodestyle --config=pycodestyle.ini searchguard tests
 setenv = PYTHONPATH = {toxinidir}
-         SEARCHGUARD_API_URL = "https://dummy-url.example.com:1234/"
-         SEARCHGUARD_API_USER = "user"
-         SEARCHGUARD_API_PASS = "password"


### PR DESCRIPTION
The `settings` module reads API URL and credentials from environment variables. In production this is OK, but this means the environment variables must be defined if anywhere we just `import` the package.

This PR relaxes the dependence on the environment variables by falling back to empty values, so that the environment variables are not required when the module is imported, giving a chance to set the settings from different source, and easier to set in test environments.