### PR TITLE
internalusers.create_user optionally accepts a password

### DIFF
--- a/searchguard/internalusers.py
+++ b/searchguard/internalusers.py
@@ -29,17 +29,20 @@ def check_user_exists(username):
         raise CheckUserExistsException('Unknown error checking whether user {} exists'.format(username))
 
 
-def create_user(username):
+def create_user(username, password=None):
     """Creates a new Search Guard user and returns the generated password
 
     :param str username: the username
+    :param str password: the password (by default will generate a password)
     :raises: UserAlreadyExistsException, CreateUserException
+    :return str: generated password
     """
     if check_user_exists(username):
         raise UserAlreadyExistsException('User {} already exists'.format(username))
 
     # The username does not exist, let's create it
-    password = password_generator()
+    if not password:
+        password = password_generator()
     payload = {'password': password}
     create_sg_user = requests.put('{}/internalusers/{}'.format(SGAPI, username),
                                   data=json.dumps(payload), headers=HEADER, auth=TOKEN)

--- a/tests/tests_internalusers/test_create_user.py
+++ b/tests/tests_internalusers/test_create_user.py
@@ -31,6 +31,15 @@ class TestCreateUser(BaseTestCase):
         ret = create_user(self.user)
         self.assertEqual(len(ret), 25)
 
+    def test_create_user_accepts_optional_password(self):
+        ret = create_user(self.user, 'sample_password')
+        self.assertEqual(ret, 'sample_password')
+
+    @patch('searchguard.internalusers.password_generator')
+    def test_create_user_wont_generate_password_if_its_passed_in(self, mock_password_generator):
+        ret = create_user(self.user, 'sample_password')
+        mock_password_generator.assert_not_called()
+
     def test_create_user_raises_create_exception_when_user_already_exists(self):
         self.mocked_check_user_exists.return_value = True
 


### PR DESCRIPTION
`internalusers.create_user` generates a random password and returns it so the caller can use/store that value. However it could be that a caller would need to use a specific password for users (say a shared auth DB with other systems, etc.), then it's not easy to integrate with this tool.
This PR allows the caller of `create_user` to optionally specify a password to support such situations.
