### PR TITLE
internalusers.create_password accepts properties (API request body)

### DIFF
--- a/searchguard/internalusers.py
+++ b/searchguard/internalusers.py
@@ -57,10 +57,9 @@ def create_user(username, password=None, properties=None):
     if 'hash' in properties:
         password = ''  # password is not effective, return empty string
     elif 'password' in properties:
-        password = properties['password']
+        password = properties['password']  # return the effective password
     else:
-        if not password:
-            password = password_generator()
+        password = password or password_generator()
         properties['password'] = password
 
     create_sg_user = requests.put('{}/internalusers/{}'.format(SGAPI, username),

--- a/searchguard/internalusers.py
+++ b/searchguard/internalusers.py
@@ -29,23 +29,42 @@ def check_user_exists(username):
         raise CheckUserExistsException('Unknown error checking whether user {} exists'.format(username))
 
 
-def create_user(username, password=None):
+def create_user(username, password=None, properties=None):
     """Creates a new Search Guard user and returns the generated password
 
     :param str username: the username
     :param str password: the password (by default will generate a password)
-    :raises: UserAlreadyExistsException, CreateUserException
-    :return str: generated password
+    :param dict properties: dict of user properties (roles, attributes, hash, etc), matching
+    the API request body. Following the API, if "hash" is specified the password
+    won't be used, then the return value is empty string.
+    If password is passed both explicitly and as a property,
+    mismatching passwords would raise a ValueError.
+
+    :raises: UserAlreadyExistsException, CreateUserException, ValueError
+    :return str: password, or if hash is used empty string
     """
     if check_user_exists(username):
         raise UserAlreadyExistsException('User {} already exists'.format(username))
 
     # The username does not exist, let's create it
-    if not password:
-        password = password_generator()
-    payload = {'password': password}
+    if not properties:
+        properties = dict()
+
+    if 'password' in properties and password and (password != properties['password']):
+        raise ValueError("Password argument is different than 'password' property")
+
+    # decide returned password value and request body password according to arguments
+    if 'hash' in properties:
+        password = ''  # password is not effective, return empty string
+    elif 'password' in properties:
+        password = properties['password']
+    else:
+        if not password:
+            password = password_generator()
+        properties['password'] = password
+
     create_sg_user = requests.put('{}/internalusers/{}'.format(SGAPI, username),
-                                  data=json.dumps(payload), headers=HEADER, auth=TOKEN)
+                                  data=json.dumps(properties), headers=HEADER, auth=TOKEN)
 
     if create_sg_user.status_code == 201:
         # User created successfully

--- a/tests/tests_internalusers/test_create_user.py
+++ b/tests/tests_internalusers/test_create_user.py
@@ -12,6 +12,14 @@ class TestCreateUser(BaseTestCase):
 
     def setUp(self):
         self.user = "DummyUser"
+        self.properties = {
+            "password": "abcd1234",
+            "roles": ["testrole"],
+            "attributes": {
+                "attr1": "value1",
+                "attr2": "value2",
+            }
+        }
         self.api_url = "fake_api_url/internalusers/"
         self.set_up_patch('searchguard.internalusers.SGAPI', "fake_api_url")
 
@@ -27,11 +35,11 @@ class TestCreateUser(BaseTestCase):
         ret = create_user(self.user)
         self.assertEqual(ret, "abc1234")
 
-    def test_create_user_returns_25_char_password_when_successfully_created_user(self):
+    def test_create_user_returns_25_char_password_when_generated_a_password(self):
         ret = create_user(self.user)
         self.assertEqual(len(ret), 25)
 
-    def test_create_user_accepts_optional_password(self):
+    def test_create_user_accepts_optional_password_and_returns_it(self):
         ret = create_user(self.user, 'sample_password')
         self.assertEqual(ret, 'sample_password')
 
@@ -39,6 +47,40 @@ class TestCreateUser(BaseTestCase):
     def test_create_user_wont_generate_password_if_its_passed_in(self, mock_password_generator):
         ret = create_user(self.user, 'sample_password')
         mock_password_generator.assert_not_called()
+
+    def test_create_user_returns_password_in_properties_if_set(self):
+        ret = create_user(self.user, None, dict(password='password_in_properties'))
+        self.assertEqual(ret, 'password_in_properties')
+
+    @patch('searchguard.internalusers.password_generator')
+    def test_create_user_wont_generate_password_if_properties_contain_password(self, mock_password_generator):
+        ret = create_user(self.user, None, dict(password='password_in_properties'))
+        mock_password_generator.assert_not_called()
+
+    def test_create_user_returns_empty_string_if_properties_contain_hash(self):
+        ret = create_user(self.user, None, {'hash': 'buYQkJcKxsz4JO50X8SqbJE9Cth5dJI'})
+        self.assertEqual(ret, '')
+
+    @patch('searchguard.internalusers.password_generator')
+    def test_create_user_wont_generate_password_if_properties_contain_hash(self, mock_password_generator):
+        ret = create_user(self.user, None, {'hash': 'buYQkJcKxsz4JO50X8SqbJE9Cth5dJI'})
+        mock_password_generator.assert_not_called()
+
+    @patch('searchguard.internalusers.password_generator')
+    def test_create_user_wont_generate_password_if_its_passed_in(self, mock_password_generator):
+        ret = create_user(self.user, 'sample_password')
+        mock_password_generator.assert_not_called()
+
+    def test_create_user_raises_value_error_when_password_does_not_match_properties_password(self):
+        with self.assertRaises(ValueError):
+            create_user(self.user, 'efgh5678', self.properties)
+        self.mocked_requests_put.assert_not_called()
+
+    def test_create_user_raises_value_error_when_password_does_not_match_properties_password_with_hash(self):
+        self.properties['hash'] = 'buYQkJcKxsz4JO50X8SqbJE9Cth5dJI'
+        with self.assertRaises(ValueError):
+            create_user(self.user, 'efgh5678', self.properties)
+        self.mocked_requests_put.assert_not_called()
 
     def test_create_user_raises_create_exception_when_user_already_exists(self):
         self.mocked_check_user_exists.return_value = True
@@ -67,7 +109,7 @@ class TestCreateUser(BaseTestCase):
         self.assertTrue(password_generator())
 
     @patch('searchguard.internalusers.password_generator')
-    def test_create_user_calls_requests_with_correct_arguments(self, mock_password_generator):
+    def test_create_user_calls_api_with_correct_arguments_when_generating_password(self, mock_password_generator):
         mock_password_generator.return_value = "abc1234"
 
         create_user(self.user)
@@ -75,4 +117,43 @@ class TestCreateUser(BaseTestCase):
         self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
                                                          auth=(mock.ANY, mock.ANY),
                                                          data=json.dumps(data),
+                                                         headers={'content-type': 'application/json'})
+
+    def test_create_user_calls_api_with_correct_arguments_when_explicit_password(self):
+        create_user(self.user, "efg5678")
+        data = {"password": "efg5678"}
+        self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
+                                                         auth=(mock.ANY, mock.ANY),
+                                                         data=json.dumps(data),
+                                                         headers={'content-type': 'application/json'})
+
+    def test_create_user_calls_api_with_correct_arguments_when_properties_has_hash(self):
+        self.properties['hash'] = 'buYQkJcKxsz4JO50X8SqbJE9Cth5dJI'
+        create_user(self.user, properties=self.properties)
+        self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
+                                                         auth=(mock.ANY, mock.ANY),
+                                                         data=json.dumps(self.properties),
+                                                         headers={'content-type': 'application/json'})
+
+    def test_create_user_calls_api_with_correct_arguments_when_properties_has_hash_only(self):
+        self.properties['hash'] = 'buYQkJcKxsz4JO50X8SqbJE9Cth5dJI'
+        del self.properties['password']
+        create_user(self.user, properties=self.properties)
+        self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
+                                                         auth=(mock.ANY, mock.ANY),
+                                                         data=json.dumps(self.properties),
+                                                         headers={'content-type': 'application/json'})
+
+    def test_create_user_calls_api_with_correct_arguments_when_properties_has_password_only(self):
+        create_user(self.user, properties=self.properties)
+        self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
+                                                         auth=(mock.ANY, mock.ANY),
+                                                         data=json.dumps(self.properties),
+                                                         headers={'content-type': 'application/json'})
+
+    def test_create_user_calls_api_with_correct_arguments_when_password_matches_properties(self):
+        create_user(self.user, 'abcd1234', self.properties)
+        self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
+                                                         auth=(mock.ANY, mock.ANY),
+                                                         data=json.dumps(self.properties),
                                                          headers={'content-type': 'application/json'})


### PR DESCRIPTION
So the caller can specify roles or other attributes, and it's possible to specify the password hash (instead of the password itself).

Since the password itself is one of the acceptable properties, it's possible to pass the password as one of the properties, but to avoid ambiguity, if the password is also defined explicitly (not required) and it does not match the specified password in properties, a `ValueError` is raised.

So the password can be specified:

 - Just an explicit argument for password
 - Only as a property, with no explicit password argument
 - Both as explicit password argument and a property, but only if they
 match