### PR TITLE
Rename settings

### DIFF
--- a/searchguard/internalusers.py
+++ b/searchguard/internalusers.py
@@ -6,7 +6,7 @@ import json
 import random
 import string
 from searchguard.exceptions import *
-from searchguard.settings import HEADER, SGAPI, TOKEN
+from searchguard.settings import HEADER, SGAPI, SEARCHGUARD_API_AUTH
 
 
 def password_generator(size=25, chars=string.ascii_uppercase + string.ascii_lowercase + string.digits):
@@ -16,7 +16,7 @@ def password_generator(size=25, chars=string.ascii_uppercase + string.ascii_lowe
 
 def check_user_exists(username):
     """Returns True of False depending on whether the requested user exists in Search Guard"""
-    user_exists_check = requests.get('{}/internalusers/{}'.format(SGAPI, username), auth=TOKEN)
+    user_exists_check = requests.get('{}/internalusers/{}'.format(SGAPI, username), auth=SEARCHGUARD_API_AUTH)
 
     if user_exists_check.status_code == 200:
         # Username exists in SearchGuard
@@ -63,7 +63,7 @@ def create_user(username, password=None, properties=None):
         properties['password'] = password
 
     create_sg_user = requests.put('{}/internalusers/{}'.format(SGAPI, username),
-                                  data=json.dumps(properties), headers=HEADER, auth=TOKEN)
+                                  data=json.dumps(properties), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
 
     if create_sg_user.status_code == 201:
         # User created successfully
@@ -78,7 +78,7 @@ def modify_user(user, properties):
     if check_user_exists(user):
         # The user does exist, let's modify it
         modify_sg_user = requests.put('{}/internalusers/{}'.format(SGAPI, user),
-                                      data=json.dumps(properties), headers=HEADER, auth=TOKEN)
+                                      data=json.dumps(properties), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
 
         if modify_sg_user.status_code == 200:
             # User modified successfully
@@ -98,7 +98,7 @@ def delete_user(username):
         raise DeleteUserException('Error deleting the user {}, does not exist'.format(username))
 
     # The user does exist, let's delete it
-    delete_sg_user = requests.delete('{}/internalusers/{}'.format(SGAPI, username), auth=TOKEN)
+    delete_sg_user = requests.delete('{}/internalusers/{}'.format(SGAPI, username), auth=SEARCHGUARD_API_AUTH)
 
     if delete_sg_user.status_code != 200:
         # Raise exception because we could not delete the user
@@ -112,7 +112,7 @@ def view_user(user):
     """
     if check_user_exists(user):
         # The user does exist, let's view it
-        view_sg_user = requests.get('{}/internalusers/{}'.format(SGAPI, user), auth=TOKEN)
+        view_sg_user = requests.get('{}/internalusers/{}'.format(SGAPI, user), auth=SEARCHGUARD_API_AUTH)
 
         if view_sg_user.status_code == 200:
             return view_sg_user.text
@@ -130,7 +130,7 @@ def list_users(prefix=None, search=None):
     :param str prefix: Return only users that match this prefix (underscore is used as delimiter)
     :param str search: Return only users that contain this search string
     """
-    response = requests.get('{}/internalusers/'.format(SGAPI), auth=TOKEN)
+    response = requests.get('{}/internalusers/'.format(SGAPI), auth=SEARCHGUARD_API_AUTH)
 
     if response.status_code == 200:
         list_sg_users = json.loads(response.text)

--- a/searchguard/internalusers.py
+++ b/searchguard/internalusers.py
@@ -6,7 +6,7 @@ import json
 import random
 import string
 from searchguard.exceptions import *
-from searchguard.settings import HEADER, SGAPI, SEARCHGUARD_API_AUTH
+from searchguard.settings import HEADER, SEARCHGUARD_API_URL, SEARCHGUARD_API_AUTH
 
 
 def password_generator(size=25, chars=string.ascii_uppercase + string.ascii_lowercase + string.digits):
@@ -16,7 +16,7 @@ def password_generator(size=25, chars=string.ascii_uppercase + string.ascii_lowe
 
 def check_user_exists(username):
     """Returns True of False depending on whether the requested user exists in Search Guard"""
-    user_exists_check = requests.get('{}/internalusers/{}'.format(SGAPI, username), auth=SEARCHGUARD_API_AUTH)
+    user_exists_check = requests.get('{}/internalusers/{}'.format(SEARCHGUARD_API_URL, username), auth=SEARCHGUARD_API_AUTH)
 
     if user_exists_check.status_code == 200:
         # Username exists in SearchGuard
@@ -62,7 +62,7 @@ def create_user(username, password=None, properties=None):
         password = password or password_generator()
         properties['password'] = password
 
-    create_sg_user = requests.put('{}/internalusers/{}'.format(SGAPI, username),
+    create_sg_user = requests.put('{}/internalusers/{}'.format(SEARCHGUARD_API_URL, username),
                                   data=json.dumps(properties), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
 
     if create_sg_user.status_code == 201:
@@ -77,7 +77,7 @@ def modify_user(user, properties):
     """Modifies a Search Guard user. Returns when successfully modified"""
     if check_user_exists(user):
         # The user does exist, let's modify it
-        modify_sg_user = requests.put('{}/internalusers/{}'.format(SGAPI, user),
+        modify_sg_user = requests.put('{}/internalusers/{}'.format(SEARCHGUARD_API_URL, user),
                                       data=json.dumps(properties), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
 
         if modify_sg_user.status_code == 200:
@@ -98,7 +98,7 @@ def delete_user(username):
         raise DeleteUserException('Error deleting the user {}, does not exist'.format(username))
 
     # The user does exist, let's delete it
-    delete_sg_user = requests.delete('{}/internalusers/{}'.format(SGAPI, username), auth=SEARCHGUARD_API_AUTH)
+    delete_sg_user = requests.delete('{}/internalusers/{}'.format(SEARCHGUARD_API_URL, username), auth=SEARCHGUARD_API_AUTH)
 
     if delete_sg_user.status_code != 200:
         # Raise exception because we could not delete the user
@@ -112,7 +112,7 @@ def view_user(user):
     """
     if check_user_exists(user):
         # The user does exist, let's view it
-        view_sg_user = requests.get('{}/internalusers/{}'.format(SGAPI, user), auth=SEARCHGUARD_API_AUTH)
+        view_sg_user = requests.get('{}/internalusers/{}'.format(SEARCHGUARD_API_URL, user), auth=SEARCHGUARD_API_AUTH)
 
         if view_sg_user.status_code == 200:
             return view_sg_user.text
@@ -130,7 +130,7 @@ def list_users(prefix=None, search=None):
     :param str prefix: Return only users that match this prefix (underscore is used as delimiter)
     :param str search: Return only users that contain this search string
     """
-    response = requests.get('{}/internalusers/'.format(SGAPI), auth=SEARCHGUARD_API_AUTH)
+    response = requests.get('{}/internalusers/'.format(SEARCHGUARD_API_URL), auth=SEARCHGUARD_API_AUTH)
 
     if response.status_code == 200:
         list_sg_users = json.loads(response.text)

--- a/searchguard/roles.py
+++ b/searchguard/roles.py
@@ -4,12 +4,12 @@ import requests
 import warnings
 import json
 from searchguard.exceptions import *
-from searchguard.settings import HEADER, SGAPI, SEARCHGUARD_API_AUTH
+from searchguard.settings import HEADER, SEARCHGUARD_API_URL, SEARCHGUARD_API_AUTH
 
 
 def check_role_exists(role):
     """Returns True of False depending on whether the requested role exists in Search Guard"""
-    role_exists_check = requests.get('{}/roles/{}'.format(SGAPI, role), auth=SEARCHGUARD_API_AUTH)
+    role_exists_check = requests.get('{}/roles/{}'.format(SEARCHGUARD_API_URL, role), auth=SEARCHGUARD_API_AUTH)
 
     if role_exists_check.status_code == 200:
         # Role exists in SearchGuard
@@ -36,7 +36,7 @@ def create_role(role, permissions=None):
         payload = {'cluster': ["indices:data/read/mget", "indices:data/read/msearch"]}
         if permissions:
             payload = permissions
-        create_sg_role = requests.put('{}/roles/{}'.format(SGAPI, role),
+        create_sg_role = requests.put('{}/roles/{}'.format(SEARCHGUARD_API_URL, role),
                                       data=json.dumps(payload), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
 
         if create_sg_role.status_code == 201:
@@ -53,7 +53,7 @@ def modify_role(role, permissions):
     """Modifies a Search Guard role. Returns when successfully modified"""
     if check_role_exists(role):
         # The role does exist, let's modify it
-        modify_sg_role = requests.put('{}/roles/{}'.format(SGAPI, role),
+        modify_sg_role = requests.put('{}/roles/{}'.format(SEARCHGUARD_API_URL, role),
                                       data=json.dumps(permissions), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
 
         if modify_sg_role.status_code == 200:
@@ -71,7 +71,7 @@ def delete_role(role):
     """Deletes a Search Guard roles. Returns when successfully deleted"""
     if check_role_exists(role):
         # The role does exist, let's delete it
-        delete_sg_role = requests.delete('{}/roles/{}'.format(SGAPI, role), auth=SEARCHGUARD_API_AUTH)
+        delete_sg_role = requests.delete('{}/roles/{}'.format(SEARCHGUARD_API_URL, role), auth=SEARCHGUARD_API_AUTH)
 
         if delete_sg_role.status_code == 200:
             # Role deleted successfully
@@ -88,7 +88,7 @@ def view_role(role):
     """Returns the permissions for the requested role if it exists"""
     if check_role_exists(role):
         # The role does exist, let's view it
-        view_sg_role = requests.get('{}/roles/{}'.format(SGAPI, role), auth=SEARCHGUARD_API_AUTH)
+        view_sg_role = requests.get('{}/roles/{}'.format(SEARCHGUARD_API_URL, role), auth=SEARCHGUARD_API_AUTH)
 
         if view_sg_role.status_code == 200:
             return view_sg_role.text

--- a/searchguard/roles.py
+++ b/searchguard/roles.py
@@ -4,12 +4,12 @@ import requests
 import warnings
 import json
 from searchguard.exceptions import *
-from searchguard.settings import HEADER, SGAPI, TOKEN
+from searchguard.settings import HEADER, SGAPI, SEARCHGUARD_API_AUTH
 
 
 def check_role_exists(role):
     """Returns True of False depending on whether the requested role exists in Search Guard"""
-    role_exists_check = requests.get('{}/roles/{}'.format(SGAPI, role), auth=TOKEN)
+    role_exists_check = requests.get('{}/roles/{}'.format(SGAPI, role), auth=SEARCHGUARD_API_AUTH)
 
     if role_exists_check.status_code == 200:
         # Role exists in SearchGuard
@@ -37,7 +37,7 @@ def create_role(role, permissions=None):
         if permissions:
             payload = permissions
         create_sg_role = requests.put('{}/roles/{}'.format(SGAPI, role),
-                                      data=json.dumps(payload), headers=HEADER, auth=TOKEN)
+                                      data=json.dumps(payload), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
 
         if create_sg_role.status_code == 201:
             # Role created successfully
@@ -54,7 +54,7 @@ def modify_role(role, permissions):
     if check_role_exists(role):
         # The role does exist, let's modify it
         modify_sg_role = requests.put('{}/roles/{}'.format(SGAPI, role),
-                                      data=json.dumps(permissions), headers=HEADER, auth=TOKEN)
+                                      data=json.dumps(permissions), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
 
         if modify_sg_role.status_code == 200:
             # Role modified successfully
@@ -71,7 +71,7 @@ def delete_role(role):
     """Deletes a Search Guard roles. Returns when successfully deleted"""
     if check_role_exists(role):
         # The role does exist, let's delete it
-        delete_sg_role = requests.delete('{}/roles/{}'.format(SGAPI, role), auth=TOKEN)
+        delete_sg_role = requests.delete('{}/roles/{}'.format(SGAPI, role), auth=SEARCHGUARD_API_AUTH)
 
         if delete_sg_role.status_code == 200:
             # Role deleted successfully
@@ -88,7 +88,7 @@ def view_role(role):
     """Returns the permissions for the requested role if it exists"""
     if check_role_exists(role):
         # The role does exist, let's view it
-        view_sg_role = requests.get('{}/roles/{}'.format(SGAPI, role), auth=TOKEN)
+        view_sg_role = requests.get('{}/roles/{}'.format(SGAPI, role), auth=SEARCHGUARD_API_AUTH)
 
         if view_sg_role.status_code == 200:
             return view_sg_role.text

--- a/searchguard/settings.py
+++ b/searchguard/settings.py
@@ -1,5 +1,5 @@
 import os
 
 HEADER = {'content-type': 'application/json'}
-SGAPI = os.environ.get('SEARCHGUARD_API_URL', '')
+SEARCHGUARD_API_URL = os.environ.get('SEARCHGUARD_API_URL', '')
 SEARCHGUARD_API_AUTH = (os.environ.get('SEARCHGUARD_API_USER', ''), os.environ.get('SEARCHGUARD_API_PASS', ''))

--- a/searchguard/settings.py
+++ b/searchguard/settings.py
@@ -2,4 +2,4 @@ import os
 
 HEADER = {'content-type': 'application/json'}
 SGAPI = os.environ.get('SEARCHGUARD_API_URL', '')
-TOKEN = (os.environ.get('SEARCHGUARD_API_USER', ''), os.environ.get('SEARCHGUARD_API_PASS', ''))
+SEARCHGUARD_API_AUTH = (os.environ.get('SEARCHGUARD_API_USER', ''), os.environ.get('SEARCHGUARD_API_PASS', ''))

--- a/tests/tests_internalusers/test_check_user_exists.py
+++ b/tests/tests_internalusers/test_check_user_exists.py
@@ -12,7 +12,7 @@ class TestCheckUserExists(BaseTestCase):
     def setUp(self):
         self.user = "DummyUser"
         self.api_url = "fake_api_url/internalusers/"
-        self.set_up_patch('searchguard.internalusers.SGAPI', "fake_api_url")
+        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_get = self.set_up_patch('searchguard.internalusers.requests.get')
         self.mocked_requests_get.return_value = Mock(status_code=200)

--- a/tests/tests_internalusers/test_create_user.py
+++ b/tests/tests_internalusers/test_create_user.py
@@ -21,7 +21,7 @@ class TestCreateUser(BaseTestCase):
             }
         }
         self.api_url = "fake_api_url/internalusers/"
-        self.set_up_patch('searchguard.internalusers.SGAPI', "fake_api_url")
+        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_put = self.set_up_patch('searchguard.internalusers.requests.put')
         self.mocked_requests_put.return_value = Mock(status_code=201)

--- a/tests/tests_internalusers/test_delete_user.py
+++ b/tests/tests_internalusers/test_delete_user.py
@@ -12,7 +12,7 @@ class TestDeleteUser(BaseTestCase):
     def setUp(self):
         self.user = "DummyUser"
         self.api_url = "fake_api_url/internalusers/"
-        self.set_up_patch('searchguard.internalusers.SGAPI', "fake_api_url")
+        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_delete = self.set_up_patch('searchguard.internalusers.requests.delete')
         self.mocked_requests_delete.return_value = Mock(status_code=200)

--- a/tests/tests_internalusers/test_list_users.py
+++ b/tests/tests_internalusers/test_list_users.py
@@ -12,7 +12,7 @@ class TestListUsers(BaseTestCase):
 
     def setUp(self):
         self.api_url = "fake_api_url/internalusers/"
-        self.set_up_patch('searchguard.internalusers.SGAPI', "fake_api_url")
+        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.user_list_pt1 = {"dummyuser1": {"hash": "123"}}
         self.user_list_pt2 = {"999_dummyuser2": {"hash": "456", "roles": ["dummyrole2"]}}

--- a/tests/tests_internalusers/test_modify_user.py
+++ b/tests/tests_internalusers/test_modify_user.py
@@ -14,7 +14,7 @@ class TestModifyUser(BaseTestCase):
         self.user = "DummyUser"
         self.properties = {"hash": "$2a$1234", "roles": ["DummyRole"]}
         self.api_url = "fake_api_url/internalusers/"
-        self.set_up_patch('searchguard.internalusers.SGAPI', "fake_api_url")
+        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_put = self.set_up_patch('searchguard.internalusers.requests.put')
         self.mocked_requests_put.return_value = Mock(status_code=200)

--- a/tests/tests_internalusers/test_view_user.py
+++ b/tests/tests_internalusers/test_view_user.py
@@ -13,7 +13,7 @@ class TestViewUser(BaseTestCase):
         self.user = "DummyUser"
         self.api_url = "fake_api_url/internalusers/"
         self.user_data = {"DummyUser": {"roles": ["BackendRole"], "hash": "hash1234"}}
-        self.set_up_patch('searchguard.internalusers.SGAPI', "fake_api_url")
+        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_get = self.set_up_patch('searchguard.internalusers.requests.get')
         self.mocked_requests_get.return_value = Mock(status_code=200)

--- a/tests/tests_roles/test_check_role_exists.py
+++ b/tests/tests_roles/test_check_role_exists.py
@@ -12,7 +12,7 @@ class TestCheckRoleExists(BaseTestCase):
     def setUp(self):
         self.role = "DummyRole"
         self.api_url = "fake_api_url/roles/"
-        self.set_up_patch('searchguard.roles.SGAPI', "fake_api_url")
+        self.set_up_patch('searchguard.roles.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_get = self.set_up_patch('searchguard.roles.requests.get')
         self.mocked_requests_get.return_value = Mock(status_code=200)

--- a/tests/tests_roles/test_create_role.py
+++ b/tests/tests_roles/test_create_role.py
@@ -15,7 +15,7 @@ class TestCreateRole(BaseTestCase):
         self.permissions = {"cluster": ["dummyperm"], "indices": {"dummyindice": {"dummytype": ["READ"]}}}
         self.defaultperms = {"cluster": ["indices:data/read/mget", "indices:data/read/msearch"]}
         self.api_url = "fake_api_url/roles/"
-        self.set_up_patch('searchguard.roles.SGAPI', "fake_api_url")
+        self.set_up_patch('searchguard.roles.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_put = self.set_up_patch('searchguard.roles.requests.put')
         self.mocked_requests_put.return_value = Mock(status_code=201)

--- a/tests/tests_roles/test_delete_role.py
+++ b/tests/tests_roles/test_delete_role.py
@@ -12,7 +12,7 @@ class TestDeleteRole(BaseTestCase):
     def setUp(self):
         self.role = "DummyRole"
         self.api_url = "fake_api_url/roles/"
-        self.set_up_patch('searchguard.roles.SGAPI', "fake_api_url")
+        self.set_up_patch('searchguard.roles.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_delete = self.set_up_patch('searchguard.roles.requests.delete')
         self.mocked_requests_delete.return_value = Mock(status_code=200)

--- a/tests/tests_roles/test_modify_role.py
+++ b/tests/tests_roles/test_modify_role.py
@@ -14,7 +14,7 @@ class TestModifyRole(BaseTestCase):
         self.role = "DummyRole"
         self.permissions = {"cluster": ["dummyperm"], "indices": {"dummyindice": {"dummytype": ["READ"]}}}
         self.api_url = "fake_api_url/roles/"
-        self.set_up_patch('searchguard.roles.SGAPI', "fake_api_url")
+        self.set_up_patch('searchguard.roles.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_put = self.set_up_patch('searchguard.roles.requests.put')
         self.mocked_requests_put.return_value = Mock(status_code=200)

--- a/tests/tests_roles/test_view_role.py
+++ b/tests/tests_roles/test_view_role.py
@@ -13,7 +13,7 @@ class TestViewRole(BaseTestCase):
         self.role = "DummyRole"
         self.permissions = {"cluster": ["dummyperm"], "indices": {"dummyindice": {"dummytype": ["READ"]}}}
         self.api_url = "fake_api_url/roles/"
-        self.set_up_patch('searchguard.roles.SGAPI', "fake_api_url")
+        self.set_up_patch('searchguard.roles.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_get = self.set_up_patch('searchguard.roles.requests.get')
         self.mocked_requests_get.return_value = Mock(status_code=200)


### PR DESCRIPTION
Rename the `settings` module attributes to be more readable

* Rename `SGAPI` to `SEARCHGUARD_API_URL`
* Rename `TOKEN` to `SEARCHGUARD_API_AUTH`