### PR TITLE
Changes to settings are visible to roles/internalusers modules

### DIFF
--- a/searchguard/internalusers.py
+++ b/searchguard/internalusers.py
@@ -5,8 +5,8 @@ import warnings
 import json
 import random
 import string
+import searchguard.settings as settings
 from searchguard.exceptions import *
-from searchguard.settings import HEADER, SEARCHGUARD_API_URL, SEARCHGUARD_API_AUTH
 
 
 def password_generator(size=25, chars=string.ascii_uppercase + string.ascii_lowercase + string.digits):
@@ -16,7 +16,7 @@ def password_generator(size=25, chars=string.ascii_uppercase + string.ascii_lowe
 
 def check_user_exists(username):
     """Returns True of False depending on whether the requested user exists in Search Guard"""
-    user_exists_check = requests.get('{}/internalusers/{}'.format(SEARCHGUARD_API_URL, username), auth=SEARCHGUARD_API_AUTH)
+    user_exists_check = requests.get('{}/internalusers/{}'.format(settings.SEARCHGUARD_API_URL, username), auth=settings.SEARCHGUARD_API_AUTH)
 
     if user_exists_check.status_code == 200:
         # Username exists in SearchGuard
@@ -62,8 +62,8 @@ def create_user(username, password=None, properties=None):
         password = password or password_generator()
         properties['password'] = password
 
-    create_sg_user = requests.put('{}/internalusers/{}'.format(SEARCHGUARD_API_URL, username),
-                                  data=json.dumps(properties), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
+    create_sg_user = requests.put('{}/internalusers/{}'.format(settings.SEARCHGUARD_API_URL, username),
+                                  data=json.dumps(properties), headers=settings.HEADER, auth=settings.SEARCHGUARD_API_AUTH)
 
     if create_sg_user.status_code == 201:
         # User created successfully
@@ -77,8 +77,8 @@ def modify_user(user, properties):
     """Modifies a Search Guard user. Returns when successfully modified"""
     if check_user_exists(user):
         # The user does exist, let's modify it
-        modify_sg_user = requests.put('{}/internalusers/{}'.format(SEARCHGUARD_API_URL, user),
-                                      data=json.dumps(properties), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
+        modify_sg_user = requests.put('{}/internalusers/{}'.format(settings.SEARCHGUARD_API_URL, user),
+                                      data=json.dumps(properties), headers=settings.HEADER, auth=settings.SEARCHGUARD_API_AUTH)
 
         if modify_sg_user.status_code == 200:
             # User modified successfully
@@ -98,7 +98,7 @@ def delete_user(username):
         raise DeleteUserException('Error deleting the user {}, does not exist'.format(username))
 
     # The user does exist, let's delete it
-    delete_sg_user = requests.delete('{}/internalusers/{}'.format(SEARCHGUARD_API_URL, username), auth=SEARCHGUARD_API_AUTH)
+    delete_sg_user = requests.delete('{}/internalusers/{}'.format(settings.SEARCHGUARD_API_URL, username), auth=settings.SEARCHGUARD_API_AUTH)
 
     if delete_sg_user.status_code != 200:
         # Raise exception because we could not delete the user
@@ -112,7 +112,7 @@ def view_user(user):
     """
     if check_user_exists(user):
         # The user does exist, let's view it
-        view_sg_user = requests.get('{}/internalusers/{}'.format(SEARCHGUARD_API_URL, user), auth=SEARCHGUARD_API_AUTH)
+        view_sg_user = requests.get('{}/internalusers/{}'.format(settings.SEARCHGUARD_API_URL, user), auth=settings.SEARCHGUARD_API_AUTH)
 
         if view_sg_user.status_code == 200:
             return view_sg_user.text
@@ -130,7 +130,7 @@ def list_users(prefix=None, search=None):
     :param str prefix: Return only users that match this prefix (underscore is used as delimiter)
     :param str search: Return only users that contain this search string
     """
-    response = requests.get('{}/internalusers/'.format(SEARCHGUARD_API_URL), auth=SEARCHGUARD_API_AUTH)
+    response = requests.get('{}/internalusers/'.format(settings.SEARCHGUARD_API_URL), auth=settings.SEARCHGUARD_API_AUTH)
 
     if response.status_code == 200:
         list_sg_users = json.loads(response.text)

--- a/searchguard/roles.py
+++ b/searchguard/roles.py
@@ -4,12 +4,12 @@ import requests
 import warnings
 import json
 from searchguard.exceptions import *
-from searchguard.settings import HEADER, SEARCHGUARD_API_URL, SEARCHGUARD_API_AUTH
+import searchguard.settings as settings
 
 
 def check_role_exists(role):
     """Returns True of False depending on whether the requested role exists in Search Guard"""
-    role_exists_check = requests.get('{}/roles/{}'.format(SEARCHGUARD_API_URL, role), auth=SEARCHGUARD_API_AUTH)
+    role_exists_check = requests.get('{}/roles/{}'.format(settings.SEARCHGUARD_API_URL, role), auth=settings.SEARCHGUARD_API_AUTH)
 
     if role_exists_check.status_code == 200:
         # Role exists in SearchGuard
@@ -36,8 +36,8 @@ def create_role(role, permissions=None):
         payload = {'cluster': ["indices:data/read/mget", "indices:data/read/msearch"]}
         if permissions:
             payload = permissions
-        create_sg_role = requests.put('{}/roles/{}'.format(SEARCHGUARD_API_URL, role),
-                                      data=json.dumps(payload), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
+        create_sg_role = requests.put('{}/roles/{}'.format(settings.SEARCHGUARD_API_URL, role),
+                                      data=json.dumps(payload), headers=settings.HEADER, auth=settings.SEARCHGUARD_API_AUTH)
 
         if create_sg_role.status_code == 201:
             # Role created successfully
@@ -53,8 +53,8 @@ def modify_role(role, permissions):
     """Modifies a Search Guard role. Returns when successfully modified"""
     if check_role_exists(role):
         # The role does exist, let's modify it
-        modify_sg_role = requests.put('{}/roles/{}'.format(SEARCHGUARD_API_URL, role),
-                                      data=json.dumps(permissions), headers=HEADER, auth=SEARCHGUARD_API_AUTH)
+        modify_sg_role = requests.put('{}/roles/{}'.format(settings.SEARCHGUARD_API_URL, role),
+                                      data=json.dumps(permissions), headers=settings.HEADER, auth=settings.SEARCHGUARD_API_AUTH)
 
         if modify_sg_role.status_code == 200:
             # Role modified successfully
@@ -71,7 +71,7 @@ def delete_role(role):
     """Deletes a Search Guard roles. Returns when successfully deleted"""
     if check_role_exists(role):
         # The role does exist, let's delete it
-        delete_sg_role = requests.delete('{}/roles/{}'.format(SEARCHGUARD_API_URL, role), auth=SEARCHGUARD_API_AUTH)
+        delete_sg_role = requests.delete('{}/roles/{}'.format(settings.SEARCHGUARD_API_URL, role), auth=settings.SEARCHGUARD_API_AUTH)
 
         if delete_sg_role.status_code == 200:
             # Role deleted successfully
@@ -88,7 +88,7 @@ def view_role(role):
     """Returns the permissions for the requested role if it exists"""
     if check_role_exists(role):
         # The role does exist, let's view it
-        view_sg_role = requests.get('{}/roles/{}'.format(SEARCHGUARD_API_URL, role), auth=SEARCHGUARD_API_AUTH)
+        view_sg_role = requests.get('{}/roles/{}'.format(settings.SEARCHGUARD_API_URL, role), auth=settings.SEARCHGUARD_API_AUTH)
 
         if view_sg_role.status_code == 200:
             return view_sg_role.text

--- a/tests/tests_internalusers/test_check_user_exists.py
+++ b/tests/tests_internalusers/test_check_user_exists.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
-import mock as mock
-from mock import Mock
+from mock import Mock, ANY
 from searchguard.exceptions import CheckUserExistsException
 from searchguard.internalusers import check_user_exists
 from tests.helper import BaseTestCase
@@ -12,14 +11,14 @@ class TestCheckUserExists(BaseTestCase):
     def setUp(self):
         self.user = "DummyUser"
         self.api_url = "fake_api_url/internalusers/"
-        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
+        self.set_up_patch('searchguard.settings.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_get = self.set_up_patch('searchguard.internalusers.requests.get')
         self.mocked_requests_get.return_value = Mock(status_code=200)
 
     def test_check_user_exists_calls_requests_with_correct_arguments(self):
         check_user_exists(self.user)
-        self.mocked_requests_get.assert_called_once_with('{}{}'.format(self.api_url, self.user), auth=(mock.ANY, mock.ANY))
+        self.mocked_requests_get.assert_called_once_with('{}{}'.format(self.api_url, self.user), auth=(ANY, ANY))
 
     def test_check_user_exists_returns_true_when_user_exists(self):
         ret = check_user_exists(self.user)

--- a/tests/tests_internalusers/test_create_user.py
+++ b/tests/tests_internalusers/test_create_user.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python3
 
 import json
-import mock as mock
 from tests.helper import BaseTestCase
-from mock import patch, Mock
+from mock import patch, Mock, ANY
 from searchguard.internalusers import create_user, password_generator
 from searchguard.exceptions import CreateUserException, UserAlreadyExistsException
 
@@ -21,7 +20,7 @@ class TestCreateUser(BaseTestCase):
             }
         }
         self.api_url = "fake_api_url/internalusers/"
-        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
+        self.set_up_patch('searchguard.settings.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_put = self.set_up_patch('searchguard.internalusers.requests.put')
         self.mocked_requests_put.return_value = Mock(status_code=201)
@@ -115,7 +114,7 @@ class TestCreateUser(BaseTestCase):
         create_user(self.user)
         data = {"password": "abc1234"}
         self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
-                                                         auth=(mock.ANY, mock.ANY),
+                                                         auth=(ANY, ANY),
                                                          data=json.dumps(data),
                                                          headers={'content-type': 'application/json'})
 
@@ -123,7 +122,7 @@ class TestCreateUser(BaseTestCase):
         create_user(self.user, "efg5678")
         data = {"password": "efg5678"}
         self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
-                                                         auth=(mock.ANY, mock.ANY),
+                                                         auth=(ANY, ANY),
                                                          data=json.dumps(data),
                                                          headers={'content-type': 'application/json'})
 
@@ -131,7 +130,7 @@ class TestCreateUser(BaseTestCase):
         self.properties['hash'] = 'buYQkJcKxsz4JO50X8SqbJE9Cth5dJI'
         create_user(self.user, properties=self.properties)
         self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
-                                                         auth=(mock.ANY, mock.ANY),
+                                                         auth=(ANY, ANY),
                                                          data=json.dumps(self.properties),
                                                          headers={'content-type': 'application/json'})
 
@@ -140,20 +139,20 @@ class TestCreateUser(BaseTestCase):
         del self.properties['password']
         create_user(self.user, properties=self.properties)
         self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
-                                                         auth=(mock.ANY, mock.ANY),
+                                                         auth=(ANY, ANY),
                                                          data=json.dumps(self.properties),
                                                          headers={'content-type': 'application/json'})
 
     def test_create_user_calls_api_with_correct_arguments_when_properties_has_password_only(self):
         create_user(self.user, properties=self.properties)
         self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
-                                                         auth=(mock.ANY, mock.ANY),
+                                                         auth=(ANY, ANY),
                                                          data=json.dumps(self.properties),
                                                          headers={'content-type': 'application/json'})
 
     def test_create_user_calls_api_with_correct_arguments_when_password_matches_properties(self):
         create_user(self.user, 'abcd1234', self.properties)
         self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
-                                                         auth=(mock.ANY, mock.ANY),
+                                                         auth=(ANY, ANY),
                                                          data=json.dumps(self.properties),
                                                          headers={'content-type': 'application/json'})

--- a/tests/tests_internalusers/test_delete_user.py
+++ b/tests/tests_internalusers/test_delete_user.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
-import mock as mock
-from mock import Mock
+from mock import Mock, ANY
 from tests.helper import BaseTestCase
 from searchguard.internalusers import delete_user
 from searchguard.exceptions import DeleteUserException
@@ -12,7 +11,7 @@ class TestDeleteUser(BaseTestCase):
     def setUp(self):
         self.user = "DummyUser"
         self.api_url = "fake_api_url/internalusers/"
-        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
+        self.set_up_patch('searchguard.settings.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_delete = self.set_up_patch('searchguard.internalusers.requests.delete')
         self.mocked_requests_delete.return_value = Mock(status_code=200)
@@ -41,4 +40,4 @@ class TestDeleteUser(BaseTestCase):
     def test_delete_user_calls_requests_with_correct_arguments(self):
         delete_user(self.user)
         self.mocked_requests_delete.assert_called_once_with('{}{}'.format(self.api_url, self.user),
-                                                            auth=(mock.ANY, mock.ANY))
+                                                            auth=(ANY, ANY))

--- a/tests/tests_internalusers/test_list_users.py
+++ b/tests/tests_internalusers/test_list_users.py
@@ -1,8 +1,7 @@
 #!/usr/bin/python3
 
 import json
-import mock as mock
-from mock import Mock
+from mock import Mock, ANY
 from tests.helper import BaseTestCase
 from searchguard.internalusers import list_users
 from searchguard.exceptions import ListUsersException
@@ -12,7 +11,7 @@ class TestListUsers(BaseTestCase):
 
     def setUp(self):
         self.api_url = "fake_api_url/internalusers/"
-        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
+        self.set_up_patch('searchguard.settings.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.user_list_pt1 = {"dummyuser1": {"hash": "123"}}
         self.user_list_pt2 = {"999_dummyuser2": {"hash": "456", "roles": ["dummyrole2"]}}
@@ -58,4 +57,4 @@ class TestListUsers(BaseTestCase):
     def test_list_users_calls_requests_with_correct_arguments(self):
         list_users()
 
-        self.mocked_requests_get.assert_called_once_with('{}'.format(self.api_url), auth=(mock.ANY, mock.ANY))
+        self.mocked_requests_get.assert_called_once_with('{}'.format(self.api_url), auth=(ANY, ANY))

--- a/tests/tests_internalusers/test_modify_user.py
+++ b/tests/tests_internalusers/test_modify_user.py
@@ -1,8 +1,7 @@
 #!/usr/bin/python3
 
 import json
-import mock as mock
-from mock import Mock
+from mock import Mock, ANY
 from tests.helper import BaseTestCase
 from searchguard.internalusers import modify_user
 from searchguard.exceptions import ModifyUserException
@@ -14,7 +13,7 @@ class TestModifyUser(BaseTestCase):
         self.user = "DummyUser"
         self.properties = {"hash": "$2a$1234", "roles": ["DummyRole"]}
         self.api_url = "fake_api_url/internalusers/"
-        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
+        self.set_up_patch('searchguard.settings.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_put = self.set_up_patch('searchguard.internalusers.requests.put')
         self.mocked_requests_put.return_value = Mock(status_code=200)
@@ -43,7 +42,7 @@ class TestModifyUser(BaseTestCase):
     def test_modify_user_calls_requests_with_correct_arguments(self):
         modify_user(self.user, self.properties)
         self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.user),
-                                                         auth=(mock.ANY, mock.ANY),
+                                                         auth=(ANY, ANY),
                                                          data=json.dumps(self.properties),
                                                          headers={'content-type': 'application/json'})
 

--- a/tests/tests_internalusers/test_view_user.py
+++ b/tests/tests_internalusers/test_view_user.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
-import mock as mock
-from mock import Mock
+from mock import Mock, ANY
 from tests.helper import BaseTestCase
 from searchguard.internalusers import view_user
 from searchguard.exceptions import ViewUserException
@@ -13,7 +12,7 @@ class TestViewUser(BaseTestCase):
         self.user = "DummyUser"
         self.api_url = "fake_api_url/internalusers/"
         self.user_data = {"DummyUser": {"roles": ["BackendRole"], "hash": "hash1234"}}
-        self.set_up_patch('searchguard.internalusers.SEARCHGUARD_API_URL', "fake_api_url")
+        self.set_up_patch('searchguard.settings.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_get = self.set_up_patch('searchguard.internalusers.requests.get')
         self.mocked_requests_get.return_value = Mock(status_code=200)
@@ -45,4 +44,4 @@ class TestViewUser(BaseTestCase):
     def test_view_user_calls_requests_with_correct_arguments(self):
         view_user(self.user)
         self.mocked_requests_get.assert_called_once_with('{}{}'.format(self.api_url, self.user),
-                                                         auth=(mock.ANY, mock.ANY))
+                                                         auth=(ANY, ANY))

--- a/tests/tests_roles/test_check_role_exists.py
+++ b/tests/tests_roles/test_check_role_exists.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
-import mock as mock
-from mock import Mock
+from mock import Mock, ANY
 from tests.helper import BaseTestCase
 from searchguard.roles import check_role_exists
 from searchguard.exceptions import CheckRoleExistsException
@@ -12,14 +11,14 @@ class TestCheckRoleExists(BaseTestCase):
     def setUp(self):
         self.role = "DummyRole"
         self.api_url = "fake_api_url/roles/"
-        self.set_up_patch('searchguard.roles.SEARCHGUARD_API_URL', "fake_api_url")
+        self.set_up_patch('searchguard.settings.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_get = self.set_up_patch('searchguard.roles.requests.get')
         self.mocked_requests_get.return_value = Mock(status_code=200)
 
     def test_check_role_exists_calls_requests_with_correct_arguments(self):
         check_role_exists(self.role)
-        self.mocked_requests_get.assert_called_once_with('{}{}'.format(self.api_url, self.role), auth=(mock.ANY, mock.ANY))
+        self.mocked_requests_get.assert_called_once_with('{}{}'.format(self.api_url, self.role), auth=(ANY, ANY))
 
     def test_check_role_exists_returns_true_when_role_exists(self):
         ret = check_role_exists(self.role)

--- a/tests/tests_roles/test_create_role.py
+++ b/tests/tests_roles/test_create_role.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python3
 
 import json
-import mock as mock
 from tests.helper import BaseTestCase
-from mock import Mock
+from mock import Mock, ANY
 from searchguard.roles import create_role
 from searchguard.exceptions import CreateRoleException, RoleAlreadyExistsException
 
@@ -15,7 +14,7 @@ class TestCreateRole(BaseTestCase):
         self.permissions = {"cluster": ["dummyperm"], "indices": {"dummyindice": {"dummytype": ["READ"]}}}
         self.defaultperms = {"cluster": ["indices:data/read/mget", "indices:data/read/msearch"]}
         self.api_url = "fake_api_url/roles/"
-        self.set_up_patch('searchguard.roles.SEARCHGUARD_API_URL', "fake_api_url")
+        self.set_up_patch('searchguard.settings.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_put = self.set_up_patch('searchguard.roles.requests.put')
         self.mocked_requests_put.return_value = Mock(status_code=201)
@@ -50,13 +49,13 @@ class TestCreateRole(BaseTestCase):
     def test_create_role_wo_perms_calls_requests_put_with_correct_arguments(self):
         create_role(self.role)
         self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.role),
-                                                         auth=(mock.ANY, mock.ANY),
+                                                         auth=(ANY, ANY),
                                                          data=json.dumps(self.defaultperms),
                                                          headers={'content-type': 'application/json'})
 
     def test_create_role_with_perms_calls_requests_put_with_correct_arguments(self):
         create_role(self.role, self.permissions)
         self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.role),
-                                                         auth=(mock.ANY, mock.ANY),
+                                                         auth=(ANY, ANY),
                                                          data=json.dumps(self.permissions),
                                                          headers={'content-type': 'application/json'})

--- a/tests/tests_roles/test_delete_role.py
+++ b/tests/tests_roles/test_delete_role.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
-import mock as mock
-from mock import Mock
+from mock import Mock, ANY
 from tests.helper import BaseTestCase
 from searchguard.roles import delete_role
 from searchguard.exceptions import DeleteRoleException
@@ -12,7 +11,7 @@ class TestDeleteRole(BaseTestCase):
     def setUp(self):
         self.role = "DummyRole"
         self.api_url = "fake_api_url/roles/"
-        self.set_up_patch('searchguard.roles.SEARCHGUARD_API_URL', "fake_api_url")
+        self.set_up_patch('searchguard.settings.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_delete = self.set_up_patch('searchguard.roles.requests.delete')
         self.mocked_requests_delete.return_value = Mock(status_code=200)
@@ -41,4 +40,4 @@ class TestDeleteRole(BaseTestCase):
     def test_delete_role_calls_requests_with_correct_arguments(self):
         delete_role(self.role)
         self.mocked_requests_delete.assert_called_once_with('{}{}'.format(self.api_url, self.role),
-                                                            auth=(mock.ANY, mock.ANY))
+                                                            auth=(ANY, ANY))

--- a/tests/tests_roles/test_modify_role.py
+++ b/tests/tests_roles/test_modify_role.py
@@ -1,8 +1,7 @@
 #!/usr/bin/python3
 
 import json
-import mock as mock
-from mock import Mock
+from mock import Mock, ANY
 from tests.helper import BaseTestCase
 from searchguard.roles import modify_role
 from searchguard.exceptions import ModifyRoleException
@@ -14,7 +13,7 @@ class TestModifyRole(BaseTestCase):
         self.role = "DummyRole"
         self.permissions = {"cluster": ["dummyperm"], "indices": {"dummyindice": {"dummytype": ["READ"]}}}
         self.api_url = "fake_api_url/roles/"
-        self.set_up_patch('searchguard.roles.SEARCHGUARD_API_URL', "fake_api_url")
+        self.set_up_patch('searchguard.settings.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_put = self.set_up_patch('searchguard.roles.requests.put')
         self.mocked_requests_put.return_value = Mock(status_code=200)
@@ -43,7 +42,7 @@ class TestModifyRole(BaseTestCase):
     def test_modify_role_calls_requests_with_correct_arguments(self):
         modify_role(self.role, self.permissions)
         self.mocked_requests_put.assert_called_once_with('{}{}'.format(self.api_url, self.role),
-                                                         auth=(mock.ANY, mock.ANY),
+                                                         auth=(ANY, ANY),
                                                          data=json.dumps(self.permissions),
                                                          headers={'content-type': 'application/json'})
 

--- a/tests/tests_roles/test_view_role.py
+++ b/tests/tests_roles/test_view_role.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
-import mock as mock
-from mock import Mock
+from mock import Mock, ANY
 from searchguard.roles import view_role
 from searchguard.exceptions import ViewRoleException
 from tests.helper import BaseTestCase
@@ -13,7 +12,7 @@ class TestViewRole(BaseTestCase):
         self.role = "DummyRole"
         self.permissions = {"cluster": ["dummyperm"], "indices": {"dummyindice": {"dummytype": ["READ"]}}}
         self.api_url = "fake_api_url/roles/"
-        self.set_up_patch('searchguard.roles.SEARCHGUARD_API_URL', "fake_api_url")
+        self.set_up_patch('searchguard.settings.SEARCHGUARD_API_URL', "fake_api_url")
 
         self.mocked_requests_get = self.set_up_patch('searchguard.roles.requests.get')
         self.mocked_requests_get.return_value = Mock(status_code=200)
@@ -45,4 +44,4 @@ class TestViewRole(BaseTestCase):
     def test_view_role_calls_requests_with_correct_arguments(self):
         view_role(self.role)
         self.mocked_requests_get.assert_called_once_with('{}{}'.format(self.api_url, self.role),
-                                                         auth=(mock.ANY, mock.ANY))
+                                                         auth=(ANY, ANY))


### PR DESCRIPTION
We were using `from settings import foo` style importing for [settings](https://github.com/ByteInternet/searchguard-python/blob/cd7ff807510883fd948f086fd44251a1df9951cd/searchguard/settings.py#L4) (API URL, AUTH, etc.) in other modules ([internalusers](https://github.com/ByteInternet/searchguard-python/blob/cd7ff807510883fd948f086fd44251a1df9951cd/searchguard/internalusers.py#L9)/[roles](https://github.com/ByteInternet/searchguard-python/blob/cd7ff807510883fd948f086fd44251a1df9951cd/searchguard/roles.py#L7)). That caused the settings to be copied to the modules (the settings
are string values, copied by value), changes later to the settings were not affecting the module behaviors.

With this commit those modules use FQN when accessing the settings, so the changes to the settings is going to be effective.

Also replaced `mock.ANY` to `ANY` in tests and remove `import mock as mock`.