### PR TITLE
Exclude rolemappings that raise errors in list for user

### DIFF
--- a/searchguard/rolesmapping.py
+++ b/searchguard/rolesmapping.py
@@ -169,7 +169,7 @@ def modify_rolemapping(role, properties, action="replace"):
 
 def list_rolemappings_for_user(user, roles=None, skip_missing_roles=False):
     """Get list of rolemappings that contain the given user. It is possible to add a list of roles to check.
-    If no list is added, all rolemappings are evaluated. Non-existent roles are excluded.
+    If no list is added, all rolemappings are evaluated. Non-existent roles can be excluded.
 
     :param str user: Name of user
     :param list roles: List of rolemappings to be checked for the given user

--- a/searchguard/rolesmapping.py
+++ b/searchguard/rolesmapping.py
@@ -169,7 +169,7 @@ def modify_rolemapping(role, properties, action="replace"):
 
 def list_rolemappings_for_user(user, roles=None):
     """Get list of rolemappings that contain the given user. It is possible to add a list of roles to check.
-    If no list is added, all rolemappings are evaluated.
+    If no list is added, all rolemappings are evaluated. Non-existant roles are excluded.
 
     :param str user: Name of user
     :param list roles: List of rolemappings to be checked for the given user
@@ -177,7 +177,14 @@ def list_rolemappings_for_user(user, roles=None):
     :raises: ViewRoleMappingException
     """
     if roles:
-        user_rolemappings = [role for role in roles if user in view_rolemapping(role)[role]['users']]
+        user_rolemappings = list()
+
+        for role in roles:
+            try:
+                if user in view_rolemapping(role)[role]['users']:
+                    user_rolemappings.append(role)
+            except ViewRoleMappingException:
+                pass
     else:
         user_rolemappings = [r for r, p in view_all_rolemappings().items() if user in p['users']]
 

--- a/searchguard/rolesmapping.py
+++ b/searchguard/rolesmapping.py
@@ -169,7 +169,7 @@ def modify_rolemapping(role, properties, action="replace"):
 
 def list_rolemappings_for_user(user, roles=None):
     """Get list of rolemappings that contain the given user. It is possible to add a list of roles to check.
-    If no list is added, all rolemappings are evaluated. Non-existant roles are excluded.
+    If no list is added, all rolemappings are evaluated. Non-existent roles are excluded.
 
     :param str user: Name of user
     :param list roles: List of rolemappings to be checked for the given user

--- a/searchguard/rolesmapping.py
+++ b/searchguard/rolesmapping.py
@@ -167,24 +167,29 @@ def modify_rolemapping(role, properties, action="replace"):
     _send_api_request(role, properties)
 
 
-def list_rolemappings_for_user(user, roles=None):
+def list_rolemappings_for_user(user, roles=None, skip_missing_roles=False):
     """Get list of rolemappings that contain the given user. It is possible to add a list of roles to check.
     If no list is added, all rolemappings are evaluated. Non-existent roles are excluded.
 
     :param str user: Name of user
     :param list roles: List of rolemappings to be checked for the given user
+    :param bool skip_missing_roles: Skip missing roles or throw ViewRoleMappingException
     :returns list: list of rolemappings with the given user
     :raises: ViewRoleMappingException
     """
     if roles:
-        user_rolemappings = list()
+        if skip_missing_roles:
+            user_rolemappings = list()
 
-        for role in roles:
-            try:
-                if user in view_rolemapping(role)[role]['users']:
-                    user_rolemappings.append(role)
-            except ViewRoleMappingException:
-                pass
+            for role in roles:
+                try:
+                    if user in view_rolemapping(role)[role]['users']:
+                        user_rolemappings.append(role)
+                except ViewRoleMappingException:
+                    pass
+        else:
+            user_rolemappings = [role for role in roles if user in view_rolemapping(role)[role]['users']]
+
     else:
         user_rolemappings = [r for r, p in view_all_rolemappings().items() if user in p['users']]
 

--- a/tests/tests_rolesmapping/test_list_rolemappings_for_user.py
+++ b/tests/tests_rolesmapping/test_list_rolemappings_for_user.py
@@ -39,9 +39,15 @@ class TestListRolemappingsForUser(BaseTestCase):
         ret = list_rolemappings_for_user(self.user, self.roles)
         self.assertEqual(ret, [])
 
-    def test_list_rolemappings_for_user_returns_list_without_rolemappings_that_raise_exception(self):
+    def test_list_rolemappings_for_user_returns_list_without_rolemappings_that_raise_exception_if_skip_missing_roles(self):
         self.mock_view_rolemapping.side_effect = [self.all_roles[0], ViewRoleMappingException, self.all_roles[2]]
 
-        ret = list_rolemappings_for_user(self.user, self.roles)
+        ret = list_rolemappings_for_user(self.user, self.roles, skip_missing_roles=True)
 
         self.assertListEqual(ret, ['role0', 'role2'])
+
+    def test_list_rolemappings_for_user_raises_exception_when_role_does_not_exist_if_skip_missing_roles_is_false(self):
+        self.mock_view_rolemapping.side_effect = [self.all_roles[0], ViewRoleMappingException, self.all_roles[2]]
+
+        with self.assertRaises(ViewRoleMappingException):
+            list_rolemappings_for_user(self.user, self.roles, skip_missing_roles=False)

--- a/tests/tests_rolesmapping/test_list_rolemappings_for_user.py
+++ b/tests/tests_rolesmapping/test_list_rolemappings_for_user.py
@@ -39,8 +39,9 @@ class TestListRolemappingsForUser(BaseTestCase):
         ret = list_rolemappings_for_user(self.user, self.roles)
         self.assertEqual(ret, [])
 
-    def test_list_rolemappings_for_user_raises_exception_when_role_does_not_exist(self):
+    def test_list_rolemappings_for_user_returns_list_without_rolemappings_that_raise_exception(self):
         self.mock_view_rolemapping.side_effect = [self.all_roles[0], ViewRoleMappingException, self.all_roles[2]]
 
-        with self.assertRaises(ViewRoleMappingException):
-            list_rolemappings_for_user(self.user, self.roles)
+        ret = list_rolemappings_for_user(self.user, self.roles)
+
+        self.assertListEqual(ret, ['role0', 'role2'])


### PR DESCRIPTION
Decided to change the behavior to exclude non-existent roles from the result instead of throwing an error.