### PR TITLE
Change requests requirement to be >= 2.20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=[
-        'requests==2.20'
+        'requests>=2.20'
     ],
 )
 


### PR DESCRIPTION
Using >= is better than using a hard requirement because this allows applications to select which version they want to use.